### PR TITLE
Adicionar integracao inicial

### DIFF
--- a/components/WebGIS/InfoContent.tsx
+++ b/components/WebGIS/InfoContent.tsx
@@ -8,13 +8,13 @@ export default function InfoContent() {
         variant="h6"
         component="h2"
         color="#509CBF"
-        fontFamily="inter"
+        fontFamily='Arial'
         fontWeight="800"
         fontSize="32"
       >
         SOBRE O PROJETO ECOGIS
       </Typography>
-      <Typography variant="body2" fontFamily={'inter'} sx={{ mt: 1 }}>
+      <Typography variant="body2" fontFamily={'sans-serif'} sx={{ mt: 1 }} align='justify'>
         EcoGis é uma plataforma de inteligência artificial que utiliza imagens de satélite e
         processamento de dados para mapeamento de áreas de queimadas, áreas alagadas e vegetação com
         maior precisão. A plataforma também visa apoiar diversos setores da sociedade, como o setor
@@ -29,14 +29,14 @@ export default function InfoContent() {
         variant="h6"
         component="h2"
         color="#509CBF"
-        fontFamily="inter"
+        fontFamily='Arial'
         fontWeight="800"
         fontSize="32"
         sx={{ mt: 2 }}
       >
         Laboratório Geomática e IA
       </Typography>
-      <Typography variant="body2" fontFamily={'inter'} sx={{ mt: 1 }}>
+      <Typography variant="body2" fontFamily={'sans-serif'} sx={{ mt: 1 }} align='justify'>
         O laboratório de Geomática e Inteligência Artificial utiliza técnicas e tecnologias da
         informação para gestão de dados espaciais, identificando padrões, tendências e relações para
         oferecer soluções inovadoras para desafios geográficos complexos. A Geomática abrange áreas

--- a/components/WebGIS/Map/PopupContent.tsx
+++ b/components/WebGIS/Map/PopupContent.tsx
@@ -14,16 +14,19 @@ const PopupContent: React.FC<PopupContentProps> = ({ caminhoImagem }) => {
   console.log("Caminho da imagem recebido:", caminhoImagem); // Verifique o valor aqui
 
   return (
-    <div style={{ minWidth: 200, minHeight: 150 }}>
+    <div style={{ minWidth: 150, minHeight: 150 }}>
       {caminhoImagem ? (
-        <img
-          src={caminhoImagem}
-          alt="Imagem de Local"
-          width="200"
-          height="auto"
-          onError={handleError}
-          style={{ display: imageError ? 'none' : 'block' }}
-        />
+        <a href={caminhoImagem} target="_blank" rel="noopener noreferrer">
+          <img
+            src={caminhoImagem}
+            alt="Imagem de Local"
+            width="250"
+            height="auto"
+            onError={handleError}
+            style={{ display: imageError ? 'none' : 'block' }}
+          />
+        </a>
+      
       ) : (
         <div>Nenhuma imagem disponível</div>
       )}

--- a/components/WebGIS/Map/PopupContent.tsx
+++ b/components/WebGIS/Map/PopupContent.tsx
@@ -1,17 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface PopupContentProps {
-  caminhoImagem: string | undefined;
+  caminhoImagem?: string;
 }
 
 const PopupContent: React.FC<PopupContentProps> = ({ caminhoImagem }) => {
+  const [imageError, setImageError] = useState(false);
+
+  const handleError = () => {
+    setImageError(true);
+  };
+
+  console.log("Caminho da imagem recebido:", caminhoImagem); // Verifique o valor aqui
+
   return (
-    <div style={{minWidth: 200, minHeight: 150}}>
-      {caminhoImagem &&(
-        <img src={caminhoImagem} alt="Imagem de Local" width="200" height="auto" />
+    <div style={{ minWidth: 200, minHeight: 150 }}>
+      {caminhoImagem ? (
+        <img
+          src={caminhoImagem}
+          alt="Imagem de Local"
+          width="200"
+          height="auto"
+          onError={handleError}
+          style={{ display: imageError ? 'none' : 'block' }}
+        />
+      ) : (
+        <div>Nenhuma imagem disponível</div>
       )}
+      {imageError && <div>Erro ao carregar a imagem.</div>}
     </div>
   );
 };
+
 
 export default PopupContent;

--- a/components/WebGIS/Map/PopupHandler.tsx
+++ b/components/WebGIS/Map/PopupHandler.tsx
@@ -1,36 +1,12 @@
-import React, { useState, useRef } from 'react';
-import { useMapEvents, Popup } from 'react-leaflet';
+import React  from 'react';
+import { Popup } from 'react-leaflet';
 import PopupContent from './PopupContent';
 
-const PopupHandler = () => {
-  const [popupData, setPopupData] = useState<{ lat: number; lng: number; caminhoImagem: string | undefined } | null>(
-    null
-  );
-
-  const popupRef = useRef<L.Popup | null>(null);
-
-  useMapEvents({
-    click: (e) => {
-      setPopupData({
-        lat: e.latlng.lat,
-        lng: e.latlng.lng,
-        caminhoImagem: "/marcos/teste.jpg",
-      });
-
-      if (popupRef.current) {
-        popupRef.current.setLatLng(e.latlng).openOn(e.target);
-      }
-    },
-  });
-
+const PopupHandler = ({ popupData }: { popupData: { lat: number; lng: number; caminhoImagem?: string } }) => {
   return (
-    <>
-      {popupData && (
-        <Popup ref={popupRef} position={[popupData.lat, popupData.lng]}>
-          <PopupContent caminhoImagem={popupData.caminhoImagem} />
-        </Popup>
-      )}
-    </>
+    <Popup position={[popupData.lat, popupData.lng]}>
+      <PopupContent caminhoImagem={popupData.caminhoImagem} />
+    </Popup>
   );
 };
 

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -4,7 +4,6 @@ import 'leaflet/dist/leaflet.css';
 import MapController from './MapController';
 import Location from './Location';
 import MapLayer from './MapLayer';
-import PopupHandler from './PopupHandler';
 import { Feature, Geometry } from '@turf/turf';
 import { FeatureCollection } from 'geojson';
 import axios from 'axios';
@@ -139,8 +138,6 @@ export default function Map(props: Props) {
         <MapController ref={props.forwardRef} center={defaultCenter} zoom={7} />
         <ScaleControl position="bottomleft" />
         <MapLayer type={mapType} />
-        {/* <PopupHandler /> */}
-        {limitesEstadosLayer && null}
 
         {props.showLocalizacao && <Location />}
         {renderPolygons()}

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,5 +1,5 @@
 import { RefObject, useEffect, useState } from 'react';
-import { MapContainer, Polygon, Popup, Marker, Tooltip, useMap } from 'react-leaflet';
+import { MapContainer, Polygon, Popup, Marker } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import axios from 'axios';

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -79,7 +79,7 @@ export default function Map(props: Props) {
         {/* Polígono do assentamento */}
         <Polygon
           positions={assentamento.shape.coordinates[0].map(([lng, lat]) => [lat, lng])}
-          color="blue"
+          color="rgb(192, 192, 192)"
           fillOpacity={0.5}
         >
           <Popup>Assentamento Principal</Popup>
@@ -90,7 +90,7 @@ export default function Map(props: Props) {
           <Polygon
             key={lote.id}
             positions={lote.shape.coordinates[0].map(([lng, lat]) => [lat, lng])}
-            color="yellow"
+            color="#F3FABE"
             fillOpacity={0.3}
           >
             <Popup>
@@ -133,7 +133,7 @@ export default function Map(props: Props) {
           position={[ponto.shape.coordinates[1], ponto.shape.coordinates[0]]}
           icon={L.divIcon({
             className: 'custom-icon',
-            html: '<div style="width: 10px; height: 10px; background-color: red; border-radius: 50%;"></div>',
+            html: '<div style="width: 15px; height: 15px; background-color: yellow; border-radius: 50%;"></div>',
             iconSize: [10, 10],
           })}
         >

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,13 +1,12 @@
 import { RefObject, useEffect, useState } from 'react';
-import { MapContainer, Polygon, Popup, ScaleControl } from 'react-leaflet';
+import { MapContainer, Polygon, Popup, Marker, Tooltip, useMap } from 'react-leaflet';
+import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import MapController from './MapController';
-import Location from './Location';
-import MapLayer from './MapLayer';
-import { Feature, Geometry } from '@turf/turf';
-import { FeatureCollection } from 'geojson';
 import axios from 'axios';
+import PopupHandler from './PopupHandler'; 
+import MapLayer from './MapLayer';
 
+// Tipos de dados
 interface Props {
   showLocalizacao: boolean;
   forwardRef?: RefObject<L.Map>;
@@ -23,39 +22,43 @@ interface Lote {
   proprietario: string;
 }
 
+interface Ponto {
+  id: number;
+  shape: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  codigo: string;
+}
+
+interface Foto {
+  id: number;
+  shape: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  path: string;
+}
+
 interface AssentamentoData {
   shape: {
     type: 'Polygon';
     coordinates: number[][][];
   };
   lotes: Lote[];
+  pontos: Ponto[];
+  fotos: Foto[];
 }
 
 export default function Map(props: Props) {
-  const mapType = 'satellite';
-  const [limitesEstadosLayer, setLimitesEstadosLayer] = useState<FeatureCollection | null>(null);
   const [assentamento, setAssentamento] = useState<AssentamentoData | null>(null);
-
-  useEffect(() => {
-    fetch('/BR_UF_2022.json')
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('Erro ao carregar GeoJSON');
-        }
-        return response.json();
-      })
-      .then((geojsonData: FeatureCollection) => {
-        setLimitesEstadosLayer(geojsonData);
-      })
-      .catch((err) => console.error('Erro ao carregar GeoJSON:', err));
-  }, []);
 
   useEffect(() => {
     const fetchAssentamento = async (assentamentoId: number) => {
       try {
         const response = await axios.get(`/api/assentamentos/${assentamentoId}`);
-        console.log('Dados recebidos:', response.data); 
-        setAssentamento(response.data); 
+        console.log('Dados recebidos:', response.data);
+        setAssentamento(response.data);
       } catch (error) {
         if (axios.isAxiosError(error)) {
           console.error('Erro ao buscar dados do backend:', error.response?.data || error.message);
@@ -64,19 +67,9 @@ export default function Map(props: Props) {
         }
       }
     };
-  
+
     fetchAssentamento(0);
   }, []);
-  
-
-  const defaultCenter: Feature<Geometry> = {
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [-70.811, -9.0238],
-    },
-    properties: {},
-  };
 
   const renderPolygons = () => {
     if (!assentamento) return null;
@@ -113,35 +106,73 @@ export default function Map(props: Props) {
     );
   };
 
-  return (
-    <>
-      <MapContainer
-        center={{
-          lat: -9.707326936,
-          lng: -67.411226722,
-        }}
-        zoom={7}
-        zoomControl={false}
-        minZoom={3}
-        scrollWheelZoom={true}
-        style={{ position: 'absolute', width: '100dvw', height: '100dvh', zIndex: '0' }}
-        inertia={false}
-        inertiaDeceleration={0}
-        zoomAnimation={true}
-        maxBoundsViscosity={10}
-        preferCanvas={true}
-        maxBounds={[
-          [-15.0, -60.0],
-          [-7.5, -67.8],
-        ]}
-      >
-        <MapController ref={props.forwardRef} center={defaultCenter} zoom={7} />
-        <ScaleControl position="bottomleft" />
-        <MapLayer type={mapType} />
+  const areCoordinatesClose = (
+    coord1: [number, number],
+    coord2: [number, number],
+    tolerance = 0.001
+  ): boolean => {
+    return (
+      Math.abs(coord1[0] - coord2[0]) <= tolerance &&
+      Math.abs(coord1[1] - coord2[1]) <= tolerance
+    );
+  };
+  
 
-        {props.showLocalizacao && <Location />}
-        {renderPolygons()}
-      </MapContainer>
-    </>
+  const renderPontosComFotos = () => {
+    if (!assentamento) return null;
+
+    return assentamento.pontos.map((ponto) => {
+      const fotosAssociadas = assentamento.fotos.filter((foto) =>
+        areCoordinatesClose(foto.shape.coordinates, ponto.shape.coordinates)
+      );
+      
+
+      return (
+        <Marker
+          key={ponto.id}
+          position={[ponto.shape.coordinates[1], ponto.shape.coordinates[0]]}
+          icon={L.divIcon({
+            className: 'custom-icon',
+            html: '<div style="width: 10px; height: 10px; background-color: red; border-radius: 50%;"></div>',
+            iconSize: [10, 10],
+          })}
+        >
+          <PopupHandler
+            popupData={{
+              lat: ponto.shape.coordinates[1],
+              lng: ponto.shape.coordinates[0],
+              caminhoImagem: fotosAssociadas.length > 0 ? fotosAssociadas[0].path : undefined,
+            }}
+          />
+        </Marker>
+      );
+    });
+  };
+
+  return (
+    <MapContainer
+      center={{
+        lat: -9.707326936,
+        lng: -67.411226722,
+      }}
+      zoom={10}
+      zoomControl={false}
+      minZoom={3}
+      scrollWheelZoom={true}
+      style={{ position: 'absolute', width: '100dvw', height: '100dvh', zIndex: '0' }}
+      inertia={false}
+      inertiaDeceleration={0}
+      zoomAnimation={true}
+      maxBoundsViscosity={10}
+      preferCanvas={true}
+      maxBounds={[
+        [-15.0, -80.0],
+        [-7.0, -35.0],
+      ]}
+    >
+      {renderPolygons()}
+      {renderPontosComFotos()}
+      <MapLayer type={'satellite'}></MapLayer>
+    </MapContainer>
   );
 }

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,19 +1,74 @@
-import { RefObject} from 'react';
-import { MapContainer, ScaleControl } from 'react-leaflet';
+import { RefObject, useEffect, useState } from 'react';
+import { MapContainer, Polygon, Popup, ScaleControl } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import MapController from './MapController';
 import Location from './Location';
 import MapLayer from './MapLayer';
 import PopupHandler from './PopupHandler';
 import { Feature, Geometry } from '@turf/turf';
+import { FeatureCollection } from 'geojson';
+import axios from 'axios';
 
 interface Props {
   showLocalizacao: boolean;
   forwardRef?: RefObject<L.Map>;
 }
 
+interface Lote {
+  id: number;
+  shape: {
+    type: 'Polygon';
+    coordinates: number[][][];
+  };
+  nome: string;
+  proprietario: string;
+}
+
+interface AssentamentoData {
+  shape: {
+    type: 'Polygon';
+    coordinates: number[][][];
+  };
+  lotes: Lote[];
+}
+
 export default function Map(props: Props) {
   const mapType = 'satellite';
+  const [limitesEstadosLayer, setLimitesEstadosLayer] = useState<FeatureCollection | null>(null);
+  const [assentamento, setAssentamento] = useState<AssentamentoData | null>(null);
+
+  useEffect(() => {
+    fetch('/BR_UF_2022.json')
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Erro ao carregar GeoJSON');
+        }
+        return response.json();
+      })
+      .then((geojsonData: FeatureCollection) => {
+        setLimitesEstadosLayer(geojsonData);
+      })
+      .catch((err) => console.error('Erro ao carregar GeoJSON:', err));
+  }, []);
+
+  useEffect(() => {
+    const fetchAssentamento = async (assentamentoId: number) => {
+      try {
+        const response = await axios.get(`/api/assentamentos/${assentamentoId}`);
+        console.log('Dados recebidos:', response.data); 
+        setAssentamento(response.data); 
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          console.error('Erro ao buscar dados do backend:', error.response?.data || error.message);
+        } else {
+          console.error('Erro desconhecido:', error);
+        }
+      }
+    };
+  
+    fetchAssentamento(0);
+  }, []);
+  
 
   const defaultCenter: Feature<Geometry> = {
     type: 'Feature',
@@ -24,16 +79,51 @@ export default function Map(props: Props) {
     properties: {},
   };
 
+  const renderPolygons = () => {
+    if (!assentamento) return null;
+
+    return (
+      <>
+        {/* Polígono do assentamento */}
+        <Polygon
+          positions={assentamento.shape.coordinates[0].map(([lng, lat]) => [lat, lng])}
+          color="blue"
+          fillOpacity={0.5}
+        >
+          <Popup>Assentamento Principal</Popup>
+        </Polygon>
+
+        {/* Polígonos dos lotes */}
+        {assentamento.lotes.map((lote) => (
+          <Polygon
+            key={lote.id}
+            positions={lote.shape.coordinates[0].map(([lng, lat]) => [lat, lng])}
+            color="yellow"
+            fillOpacity={0.3}
+          >
+            <Popup>
+              <div>
+                <strong>{lote.nome}</strong>
+                <br />
+                Proprietário: {lote.proprietario}
+              </div>
+            </Popup>
+          </Polygon>
+        ))}
+      </>
+    );
+  };
+
   return (
     <>
       <MapContainer
         center={{
-          lat: -70.0,
-          lng: -9.0,
+          lat: -9.707326936,
+          lng: -67.411226722,
         }}
-        zoom={0}
+        zoom={7}
         zoomControl={false}
-        minZoom={5}
+        minZoom={3}
         scrollWheelZoom={true}
         style={{ position: 'absolute', width: '100dvw', height: '100dvh', zIndex: '0' }}
         inertia={false}
@@ -42,17 +132,18 @@ export default function Map(props: Props) {
         maxBoundsViscosity={10}
         preferCanvas={true}
         maxBounds={[
-          [-11.0, -72.0],
+          [-15.0, -60.0],
           [-7.5, -67.8],
         ]}
       >
         <MapController ref={props.forwardRef} center={defaultCenter} zoom={7} />
         <ScaleControl position="bottomleft" />
         <MapLayer type={mapType} />
-        <PopupHandler />
+        {/* <PopupHandler /> */}
+        {limitesEstadosLayer && null}
 
         {props.showLocalizacao && <Location />}
-
+        {renderPolygons()}
       </MapContainer>
     </>
   );


### PR DESCRIPTION
Esse PR é responsável por adicionar uma versão inicial da integração dos dados do backend, exibindo na tela o assentamento, lotes, pontos e fotos.
O polígono maior representa o assentamento, e os polígonos menores representam os lotes.
Os pontos no mapa são relacionados com as fotos referentes à localização do ponto, com uma tolerância para conseguir capturar fotos que estejam com uma ínfima diferença de distância. Nem todos os pontos possuem necessariamente uma foto conectada.